### PR TITLE
#163818963 Add coveralls and code climate badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Politico
 
-[![Build Status](https://travis-ci.org/Mark9Mbugua/Politico-V.svg?branch=ch-add-readme-badges-%23163818963)](https://travis-ci.org/Mark9Mbugua/Politico-V)     [![Coverage Status](https://coveralls.io/repos/github/Mark9Mbugua/Politico-V/badge.svg?branch=ch-add-readme-badges-#163818963)](https://coveralls.io/github/Mark9Mbugua/Politico-V?branch=ch-add-readme-badges-#163818963) [![Maintainability](https://api.codeclimate.com/v1/badges/a99a88d28ad37a79dbf6/maintainability)](https://codeclimate.com/github/codeclimate/codeclimate/maintainability)
+[![Build Status](https://travis-ci.org/Mark9Mbugua/Politico-V.svg?branch=ch-add-readme-badges-%23163818963)](https://travis-ci.org/Mark9Mbugua/Politico-V)     [![Coverage Status](https://coveralls.io/repos/github/Mark9Mbugua/Politico-V/badge.svg?branch=ch-add-readme-badges-%23163818963)](https://coveralls.io/github/Mark9Mbugua/Politico-V?branch=ch-add-readme-badges-%23163818963) [![Maintainability](https://api.codeclimate.com/v1/badges/a99a88d28ad37a79dbf6/maintainability)](https://codeclimate.com/github/codeclimate/codeclimate/maintainability)
 
 Politico is a platform that enables citizens to give their mandate to politicians running for different government offices
 while building trust in the process through transparency.
@@ -8,7 +8,7 @@ while building trust in the process through transparency.
 ## Getting Started
 Clone the repo from GitHub:
     
-    git clone :https://github.com/Mark9Mbugua/Politico-V.git
+    git clone: https://github.com/Mark9Mbugua/Politico-V.git
 
 Navigate to root folder
     `cd Politico-V`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Politico
 
-[![Build Status](https://travis-ci.org/Mark9Mbugua/Politico-V.svg?branch=ch-integrate-travis-ci-%23163817806)](https://travis-ci.org/Mark9Mbugua/Politico-V) [![Coverage Status](https://coveralls.io/repos/github/Mark9Mbugua/Politico-V/badge.svg?branch=ch-add-readme-badges-#163818963)](https://coveralls.io/github/Mark9Mbugua/Politico-V?branch=ch-add-readme-badges-#163818963)
+[![Build Status](https://travis-ci.org/Mark9Mbugua/Politico-V.svg?branch=ch-integrate-travis-ci-%23163817806)](https://travis-ci.org/Mark9Mbugua/Politico-V)    [![Coverage Status](https://coveralls.io/repos/github/Mark9Mbugua/Politico-V/badge.svg?branch=ch-add-readme-badges-#163818963)](https://coveralls.io/github/Mark9Mbugua/Politico-V?branch=ch-add-readme-badges-#163818963)
 
 Politico is a platform that enables citizens to give their mandate to politicians running for different government offices
 while building trust in the process through transparency.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Politico
 
-[![Build Status](https://travis-ci.org/Mark9Mbugua/Politico-V.svg?branch=ch-integrate-travis-ci-%23163817806)](https://travis-ci.org/Mark9Mbugua/Politico-V)
+[![Build Status](https://travis-ci.org/Mark9Mbugua/Politico-V.svg?branch=ch-integrate-travis-ci-%23163817806)](https://travis-ci.org/Mark9Mbugua/Politico-V) [![Coverage Status](https://coveralls.io/repos/github/Mark9Mbugua/Politico-V/badge.svg?branch=ch-add-readme-badges-#163818963)](https://coveralls.io/github/Mark9Mbugua/Politico-V?branch=ch-add-readme-badges-#163818963)
 
 Politico is a platform that enables citizens to give their mandate to politicians running for different government offices
 while building trust in the process through transparency.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Politico
 
-[![Build Status](https://travis-ci.org/Mark9Mbugua/Politico-V.svg?branch=ch-integrate-travis-ci-%23163817806)](https://travis-ci.org/Mark9Mbugua/Politico-V)     [![Coverage Status](https://coveralls.io/repos/github/Mark9Mbugua/Politico-V/badge.svg?branch=ch-add-readme-badges-#163818963)](https://coveralls.io/github/Mark9Mbugua/Politico-V?branch=ch-add-readme-badges-#163818963) [![Maintainability](https://api.codeclimate.com/v1/badges/a99a88d28ad37a79dbf6/maintainability)](https://codeclimate.com/github/codeclimate/codeclimate/maintainability)
+[![Build Status](https://travis-ci.org/Mark9Mbugua/Politico-V.svg?branch=ch-add-readme-badges-%23163818963)](https://travis-ci.org/Mark9Mbugua/Politico-V)     [![Coverage Status](https://coveralls.io/repos/github/Mark9Mbugua/Politico-V/badge.svg?branch=ch-add-readme-badges-#163818963)](https://coveralls.io/github/Mark9Mbugua/Politico-V?branch=ch-add-readme-badges-#163818963) [![Maintainability](https://api.codeclimate.com/v1/badges/a99a88d28ad37a79dbf6/maintainability)](https://codeclimate.com/github/codeclimate/codeclimate/maintainability)
 
 Politico is a platform that enables citizens to give their mandate to politicians running for different government offices
 while building trust in the process through transparency.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Politico
 
-[![Build Status](https://travis-ci.org/Mark9Mbugua/Politico-V.svg?branch=ch-integrate-travis-ci-%23163817806)](https://travis-ci.org/Mark9Mbugua/Politico-V)     [![Coverage Status](https://coveralls.io/repos/github/Mark9Mbugua/Politico-V/badge.svg?branch=ch-add-readme-badges-#163818963)](https://coveralls.io/github/Mark9Mbugua/Politico-V?branch=ch-add-readme-badges-#163818963)
+[![Build Status](https://travis-ci.org/Mark9Mbugua/Politico-V.svg?branch=ch-integrate-travis-ci-%23163817806)](https://travis-ci.org/Mark9Mbugua/Politico-V)     [![Coverage Status](https://coveralls.io/repos/github/Mark9Mbugua/Politico-V/badge.svg?branch=ch-add-readme-badges-#163818963)](https://coveralls.io/github/Mark9Mbugua/Politico-V?branch=ch-add-readme-badges-#163818963) [![Maintainability](https://api.codeclimate.com/v1/badges/a99a88d28ad37a79dbf6/maintainability)](https://codeclimate.com/github/codeclimate/codeclimate/maintainability)
 
 Politico is a platform that enables citizens to give their mandate to politicians running for different government offices
 while building trust in the process through transparency.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Politico
 
-[![Build Status](https://travis-ci.org/Mark9Mbugua/Politico-V.svg?branch=ch-integrate-travis-ci-%23163817806)](https://travis-ci.org/Mark9Mbugua/Politico-V)    [![Coverage Status](https://coveralls.io/repos/github/Mark9Mbugua/Politico-V/badge.svg?branch=ch-add-readme-badges-#163818963)](https://coveralls.io/github/Mark9Mbugua/Politico-V?branch=ch-add-readme-badges-#163818963)
+[![Build Status](https://travis-ci.org/Mark9Mbugua/Politico-V.svg?branch=ch-integrate-travis-ci-%23163817806)](https://travis-ci.org/Mark9Mbugua/Politico-V)     [![Coverage Status](https://coveralls.io/repos/github/Mark9Mbugua/Politico-V/badge.svg?branch=ch-add-readme-badges-#163818963)](https://coveralls.io/github/Mark9Mbugua/Politico-V?branch=ch-add-readme-badges-#163818963)
 
 Politico is a platform that enables citizens to give their mandate to politicians running for different government offices
 while building trust in the process through transparency.


### PR DESCRIPTION
#### What does this PR do?
It adds coveralls and code climate badges to README

#### Description of Task to be completed?
- Make sure the build for TravisCI is passing
- On a web browser, visit coveralls.io
- Sync coveralls with this repo
- At the bottom of the page, obtain a markdown link for the coveralls badge and paste it on the README (in the local repo) next to the Travis CI badge. Commit this change to GitHub.
 
#### How should this be manually tested?
- Clone this repo in a local repo
- Commit changes to GitHub
- On the remote README, check if a coveralls badge exists
- Visit https://coveralls.io/ to view the build

#### What are the relevant pivotal tracker stories?
#163818963